### PR TITLE
Fixed sendConfirmationEmail function bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -333,12 +333,10 @@ module.exports = function(mongoose) {
   var sendConfirmationEmail = function(email, callback) {
     var mailOptions = JSON.parse(JSON.stringify(options.confirmMailOptions));
     mailOptions.to = email;
-    if (options.shouldSendConfirmation) {
-      if (!callback) {
-        callback = options.confirmSendMailCallback;
-      }
-      transporter.sendMail(mailOptions, callback);
+    if (!callback) {
+      callback = options.confirmSendMailCallback;
     }
+    transporter.sendMail(mailOptions, callback);
   };
 
   /**


### PR DESCRIPTION
The function shouldn't check for shouldSendConfirmation because when
calling it manually it should send regardless the option. The option is checked on other occurance.